### PR TITLE
Add non-interactive flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ VOLUME /home/monero/.bitmonero
 EXPOSE 18080 18081
 
 ENTRYPOINT ["./monerod"]
-CMD ["--restricted-rpc", "--rpc-bind-ip=0.0.0.0", "--confirm-external-bind"]
+CMD ["--non-interactive", "--restricted-rpc", "--rpc-bind-ip=0.0.0.0", "--confirm-external-bind"]


### PR DESCRIPTION
Added the command-line flag "--non-interactive" to fix a bug where the process would get stuck in an infinite restart loop in the Docker container