### PR TITLE
Use bz2 decompression on Monero CLI tools archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /root
 
 RUN curl https://downloads.getmonero.org/cli/monero-linux-x64-v$MONERO_VERSION.tar.bz2 -O &&\
   echo "$MONERO_SHA256  monero-linux-x64-v$MONERO_VERSION.tar.bz2" | sha256sum -c - &&\
-  tar -xzvf monero-linux-x64-v$MONERO_VERSION.tar.bz2 &&\
+  tar -xvf monero-linux-x64-v$MONERO_VERSION.tar.bz2 &&\
   rm monero-linux-x64-v$MONERO_VERSION.tar.bz2 &&\
   cp ./monero-x86_64-linux-gnu-v$MONERO_VERSION/monerod . &&\
   rm -r monero-*


### PR DESCRIPTION
Monero CLI tools archive is now actually in bz2 format instead of gzip with .bz2 extension